### PR TITLE
Fix npm entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
       "url": "https://github.com/talyssonoc/commonregexjs/blob/master/LICENSE"
     }
   ],
-  "main": "lib/commonregexjs",
+  "main": "lib/commonregex",
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
The "main" property in package.json was pointing to a non-existent file, and therefore would not load.
